### PR TITLE
Fix(toctree_fix): Skip entries missing fullname

### DIFF
--- a/src/sphinx_toctree_autodoc_fix.py
+++ b/src/sphinx_toctree_autodoc_fix.py
@@ -101,7 +101,9 @@ class BetterTocTreeCollector(toctree_collector.TocTreeCollector):
                         elif isinstance(node, addnodes.desc):
                             title = node.children[0]
 
-                            fullname = title.attributes["fullname"]
+                            fullname = title.attributes.get("fullname")
+                            if fullname is None:
+                                continue
                             classname = title.attributes["class"]
                             nodetype = node.attributes["objtype"]
 


### PR DESCRIPTION
sphinx-click nodes don't have a fullname