### PR TITLE
feat: Add docutils_compat, fix warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ default_section = THIRDPARTY
 include_trailing_comma = true
 multi_line_output = 3
 known_pytest = pytest,py
-known_first_party = gp_libs,doctest_docutils,linkify_issues,pytest_doctest_docutils
+known_first_party = gp_libs,doctest_compat,doctest_docutils,linkify_issues,pytest_doctest_docutils
 sections = FUTURE,STDLIB,PYTEST,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 line_length = 88
 

--- a/src/docutils_compat.py
+++ b/src/docutils_compat.py
@@ -1,0 +1,19 @@
+"""Helpers for cross compatibility across dependency versions."""
+import typing as t
+
+if t.TYPE_CHECKING:
+    from docutils.nodes import Node
+
+    _N = t.TypeVar("_N", bound=Node)
+
+
+def findall(node: t.Type["_N"]) -> t.Callable[..., t.Iterable["_N"]]:
+    """Iterate through nodes.
+
+    nodes.findall() replaces traverse in docutils v0.18.
+    findall is an iterator.
+
+    Based on myst_parser v0.18.1's:
+    https://github.com/executablebooks/MyST-Parser/blob/v0.18.1/myst_parser/_compat.py
+    """
+    return getattr(node, "findall", node.traverse)

--- a/src/linkify_issues.py
+++ b/src/linkify_issues.py
@@ -5,6 +5,8 @@ from docutils import nodes
 from sphinx.application import Sphinx
 from sphinx.transforms import SphinxTransform
 
+from docutils_compat import findall
+
 if sys.version_info >= (3, 8):
     from typing import TypedDict
 else:
@@ -40,7 +42,7 @@ class LinkifyIssues(SphinxTransform):
             )
             return cond
 
-        for node in self.document.traverse(condition):
+        for node in findall(self.document)(condition):
             text = node.astext()
             retnodes = []
             pos = 0


### PR DESCRIPTION
After upgrading libvcs's docutils to v0.19, pytest has a warning:

```
.venv/lib/python3.10/site-packages/doctest_docutils.py:328: 19 warnings
  ~/libtmux/.venv/lib/python3.10/site-packages/doctest_docutils.py:328: PendingDeprecationWarning: nodes.Node.traverse() is obsoleted by Node.findall().
    for idx, node in enumerate(doc.traverse(condition)):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```