### PR TITLE
doctest-docutils: Support for `sphinx-inline-tabs`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,27 @@ $ pip install --user --upgrade --pre gp-libs
   ```
 
 - doctest_docutils: :mod:`doctest` w/ docutils support (and markdown)
+- doctest_docutils: Support for sphinx-inline-tab's `tab` directive was added in v0.0.1a17 (#18)
+
+  `````markdown
+  ````{tab} example tab
+
+  ```python
+  >>> 4 + 4
+  8
+  ```
+
+  ````
+
+  ````{tab} example second
+
+  ```python
+  >>> 4 + 2
+  6
+  ```
+
+  ````
+  `````
 
 ### Removed features
 

--- a/src/doctest_docutils.py
+++ b/src/doctest_docutils.py
@@ -152,10 +152,23 @@ class DoctestDirective(TestDirective):
     }
 
 
+class MockTabDirective(TestDirective):
+    def run(self) -> t.List[Node]:
+        """Parse a mock-tabs directive."""
+        self.assert_has_content()
+
+        content = nodes.container("", is_div=True, classes=["tab-content"])
+        self.state.nested_parse(self.content, self.content_offset, content)
+        return [content]
+
+
 def setup() -> t.Dict[str, t.Any]:
     directives.register_directive("testsetup", TestsetupDirective)
     directives.register_directive("testcleanup", TestcleanupDirective)
     directives.register_directive("doctest", DoctestDirective)
+
+    # Third party mock directive: sphinx-inline-tabs @ 2022.01.02.beta11
+    directives.register_directive("tab", MockTabDirective)
     return {"version": docutils.__version__, "parallel_read_safe": True}
 
 

--- a/tests/test_doctest_docutils.py
+++ b/tests/test_doctest_docutils.py
@@ -158,6 +158,30 @@ Here's a test:
         },
         tests_found=1,
     ),
+    # sphinx-inline-tabs
+    DocTestFinderFixture(
+        test_id="MyST-doctest_block-python--sphinx-inline-tabs",
+        files={
+            "example.md": textwrap.dedent(
+                """
+````{tab} example tab
+```python
+>>> 4 + 4
+8
+```
+````
+
+````{tab} example second
+```python
+>>> 4 + 2
+6
+```
+````
+        """
+            )
+        },
+        tests_found=2,
+    ),
 ]
 
 

--- a/tests/test_pytest_doctest_docutils.py
+++ b/tests/test_pytest_doctest_docutils.py
@@ -163,6 +163,30 @@ def hello(statement: str) -> None:
         },
         tests_found=1,
     ),
+    # sphinx-inline-tabs
+    PytestDocTestFinderFixture(
+        test_id="MyST-doctest_block-python--sphinx-inline-tabs",
+        files={
+            "example.md": textwrap.dedent(
+                """
+````{tab} example tab
+```python
+>>> 4 + 4
+8
+```
+````
+
+````{tab} example second
+```python
+>>> 4 + 2
+6
+```
+````
+        """
+            )
+        },
+        tests_found=2,
+    ),
 ]
 
 


### PR DESCRIPTION
Fixes #17 