### PR TITLE
`RUF027` via ruff 0.7.0

### DIFF
--- a/tests/test_doctest_docutils.py
+++ b/tests/test_doctest_docutils.py
@@ -108,7 +108,7 @@ Here's a test:
     >>> 4 + 4
     8
 :::
-        """,
+        """,  # noqa: RUF027
             ),
         },
         tests_found=1,
@@ -123,7 +123,7 @@ Here's a test:
     >>> 4 + 4
     8
 ```
-        """,
+        """,  # noqa: RUF027
             ),
         },
         tests_found=1,


### PR DESCRIPTION
Command:

```
ruff check . --select RUF027 --fix --unsafe-fixes --preview --show-fixes; ruff format .;
```

Output:

```
Fixed 2 errors:
- tests/test_doctest_docutils.py:
    2 × RUF027 (missing-f-string-syntax)

Found 2 errors (2 fixed, 0 remaining).
11 files left unchanged
```