### PR TITLE
ci(tests) Verify runtime deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,17 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
+      - name: Test runtime dependencies
+        run: |
+          uv run --no-dev -p python${{ matrix.python-version }} -- python -c '
+          from gp_libs import __version__
+          from docutils_compat import findall
+          from doctest_docutils import is_allowed_version
+          from linkify_issues import LinkifyIssues
+          from pytest_doctest_docutils import pytest_addoptions
+          print("gp_libs version:", __version__)
+          '
+
       - name: Install dependencies
         run: uv sync --all-extras --dev
 


### PR DESCRIPTION
## Changes
- Add runtime dependency check in CI using `uv run --no-dev`
- Run check before installing dev dependencies
- Print package version and basic functionality test results
- Document improvement in `CHANGES`

## Summary by Sourcery

Add a CI check to verify runtime dependencies before installing dev dependencies, including a basic functionality test.

CI:
- Add a CI check to verify runtime dependencies using `uv run --no-dev` before installing dev dependencies.

Tests:
- Add a basic functionality test that prints the package version and runs a basic functionality test.