### PR TITLE
feat: Add async doctest support with top-level await

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,13 +248,14 @@ True
 >>> is_allowed_version('3.3', '>3.2, <4.0')
 True
 
-**Async doctest pattern:**
+**Async doctest pattern (top-level await):**
 ```python
+>>> import asyncio
+>>> await asyncio.sleep(0)  # Top-level await works directly
 >>> async def example():
-...     result = await some_async_function()
-...     return result
->>> asyncio.run(example())
-'expected output'
+...     return 42
+>>> await example()
+42
 ```
 
 **Using fixtures in doctests:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,8 @@ type
 **All functions and methods MUST have working doctests.** Doctests serve as both documentation and tests.
 
 **CRITICAL RULES:**
-- Doctests MUST actually execute - never comment out function calls or use placeholder output
+- Doctests MUST actually execute - never comment out function call `asyncio.run()` or similar calls
+  or use placeholder output
 - Doctests MUST NOT be converted to `.. code-block::` as a workaround (code-blocks don't run)
 - If you cannot create a working doctest, **STOP and ask for help**
 
@@ -246,6 +247,22 @@ type
 True
 >>> is_allowed_version('3.3', '>3.2, <4.0')
 True
+
+**Async doctest pattern:**
+```python
+>>> async def example():
+...     result = await some_async_function()
+...     return result
+>>> asyncio.run(example())
+'expected output'
+```
+
+**Using fixtures in doctests:**
+```python
+>>> from pathlib import Path
+>>> doc_path = tmp_path / "example.rst"  # tmp_path from doctest_namespace
+>>> doc_path.write_text(">>> 1 + 1\\n2")
+...
 ```
 
 **When output varies, use ellipsis:**
@@ -319,6 +336,119 @@ When stuck in debugging loops:
 2. **Minimize to MVP**: Remove all debugging cruft and experimental code
 3. **Document the issue** comprehensively for a fresh approach
 4. **Format for portability** (using quadruple backticks)
+
+## Asyncio Development
+
+### Async Subprocess Patterns
+
+**Always use `communicate()` for subprocess I/O:**
+```python
+proc = await asyncio.create_subprocess_shell(...)
+stdout, stderr = await proc.communicate()  # Prevents deadlocks
+```
+
+**Use `asyncio.timeout()` for timeouts:**
+```python
+async with asyncio.timeout(300):
+    stdout, stderr = await proc.communicate()
+```
+
+**Handle BrokenPipeError gracefully:**
+```python
+try:
+    proc.stdin.write(data)
+    await proc.stdin.drain()
+except BrokenPipeError:
+    pass  # Process already exited - expected behavior
+```
+
+### Async API Conventions
+
+- **Class naming**: Use `Async` prefix: `AsyncDocTestRunner`
+- **Callbacks**: Async APIs accept only async callbacks (no union types)
+- **Shared logic**: Extract argument-building to sync functions, share with async
+
+```python
+# Shared argument building (sync)
+def build_test_args(verbose: bool = False) -> dict[str, t.Any]:
+    args = {"verbose": verbose}
+    return args
+
+# Async method uses shared logic
+async def run_tests(self, verbose: bool = False) -> TestResults:
+    args = build_test_args(verbose)
+    return await self._run(**args)
+```
+
+### Async Testing
+
+**pytest configuration:**
+```toml
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
+```
+
+**Async fixture pattern:**
+```python
+@pytest_asyncio.fixture(loop_scope="function")
+async def async_doc_runner(tmp_path: Path) -> t.AsyncGenerator[AsyncDocTestRunner, None]:
+    runner = AsyncDocTestRunner(path=tmp_path)
+    yield runner
+```
+
+**Parametrized async tests:**
+```python
+class DocTestFixture(t.NamedTuple):
+    test_id: str
+    doc_content: str
+    expected: list[str]
+
+DOC_FIXTURES = [
+    DocTestFixture("basic", ">>> 1 + 1\n2", ["pass"]),
+    DocTestFixture("failure", ">>> 1 + 1\n3", ["fail"]),
+]
+
+@pytest.mark.parametrize(
+    list(DocTestFixture._fields),
+    DOC_FIXTURES,
+    ids=[f.test_id for f in DOC_FIXTURES],
+)
+@pytest.mark.asyncio
+async def test_doctest(test_id: str, doc_content: str, expected: list) -> None:
+    ...
+```
+
+### Async Anti-Patterns
+
+**DON'T poll returncode:**
+```python
+# WRONG
+while proc.returncode is None:
+    await asyncio.sleep(0.1)
+
+# RIGHT
+await proc.wait()
+```
+
+**DON'T mix blocking calls in async code:**
+```python
+# WRONG
+async def bad():
+    subprocess.run(["python", "-m", "doctest", file])  # Blocks event loop!
+
+# RIGHT
+async def good():
+    proc = await asyncio.create_subprocess_shell(...)
+    await proc.wait()
+```
+
+**DON'T close the event loop in tests:**
+```python
+# WRONG - breaks pytest-asyncio cleanup
+loop = asyncio.get_running_loop()
+loop.close()
+```
 
 ## Sphinx/Docutils-Specific Considerations
 

--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,47 @@ $ uvx --from 'gp-libs' --prerelease allow gp-libs
 
 <!-- To maintainers and contributors: Please add notes for the forthcoming version below -->
 
+### Features
+
+#### doctest_docutils
+
+- Add `AsyncDocTestRunner` for transparent top-level await support in doctests (#59)
+
+  Enables clean async doctests without `asyncio.run()` boilerplate:
+
+  ```python
+  # Before (required boilerplate)
+  >>> async def example():
+  ...     await asyncio.sleep(0)
+  ...     return 42
+  >>> asyncio.run(example())
+  42
+
+  # After (top-level await)
+  >>> await asyncio.sleep(0)
+  >>> async def fetch():
+  ...     return 42
+  >>> await fetch()
+  42
+  ```
+
+  Uses Python's `PyCF_ALLOW_TOP_LEVEL_AWAIT` compile flag (3.8+) with automatic
+  detection - sync doctests work unchanged, async doctests "just work."
+
+  Includes `_Runner310` shim for Python 3.10 compatibility (asyncio.Runner is 3.11+).
+
+#### pytest_doctest_docutils
+
+- Integrate `AsyncDocTestRunner` for async doctest support in pytest (#59)
+
+### Breaking changes
+
+#### doctest_docutils
+
+- Rename `testdocutils()` → `run_doctest_docutils()` (#59)
+
+  The function was renamed to avoid pytest automatically collecting it as a test.
+
 ### Development
 
 - Migrate from Make to just for task running (#60)

--- a/src/doctest_docutils.py
+++ b/src/doctest_docutils.py
@@ -600,6 +600,21 @@ class AsyncDocTestRunner(doctest.DocTestRunner):
     state to persist across examples within the same block.
 
     Usage is identical to doctest.DocTestRunner - async support is automatic.
+
+    Examples
+    --------
+    >>> import doctest
+    >>> from doctest_docutils import AsyncDocTestRunner
+    >>> runner = AsyncDocTestRunner(verbose=False)
+    >>> test = doctest.DocTest(
+    ...     [doctest.Example("import asyncio", ""),
+    ...      doctest.Example("await asyncio.sleep(0)", ""),
+    ...      doctest.Example("1 + 1", "2\\n")],
+    ...     {}, "example", "example.py", 0, None
+    ... )
+    >>> result = runner.run(test)
+    >>> result.failed
+    0
     """
 
     def run(

--- a/src/doctest_docutils.py
+++ b/src/doctest_docutils.py
@@ -56,11 +56,27 @@ class _Runner310(AbstractContextManager["_Runner310"]):
         debug: bool | None = None,
         loop_factory: t.Callable[[], asyncio.AbstractEventLoop] | None = None,
     ) -> None:
+        """Initialize the async runner.
+
+        Parameters
+        ----------
+        debug : bool | None, optional
+            Enable event loop debug mode, by default None
+        loop_factory : Callable[[], AbstractEventLoop] | None, optional
+            Factory function to create custom event loops, by default None
+        """
         self._debug = debug
         self._loop_factory = loop_factory
         self._loop: asyncio.AbstractEventLoop | None = None
 
     def __enter__(self) -> _Runner310:
+        """Enter the context and create the event loop.
+
+        Returns
+        -------
+        _Runner310
+            Self, for use in with-statement
+        """
         if self._loop_factory is None:
             loop = asyncio.new_event_loop()
         else:
@@ -84,6 +100,19 @@ class _Runner310(AbstractContextManager["_Runner310"]):
         exc_val: BaseException | None,
         exc_tb: t.Any,
     ) -> None:
+        """Exit the context and clean up the event loop.
+
+        Cancels pending tasks, shuts down async generators, and closes the loop.
+
+        Parameters
+        ----------
+        exc_type : type[BaseException] | None
+            Exception type if an exception was raised
+        exc_val : BaseException | None
+            Exception instance if an exception was raised
+        exc_tb : Any
+            Traceback if an exception was raised
+        """
         loop = self._loop
         if loop is None:
             return

--- a/src/doctest_docutils.py
+++ b/src/doctest_docutils.py
@@ -144,6 +144,18 @@ def _make_runner(
 
     Returns asyncio.Runner on Python 3.11+, or _Runner310 shim on 3.10.
     Both have compatible interfaces (context manager with run() method).
+
+    Parameters
+    ----------
+    debug : bool | None, optional
+        Enable event loop debug mode, by default None
+    loop_factory : Callable[[], AbstractEventLoop] | None, optional
+        Factory function to create custom event loops, by default None
+
+    Returns
+    -------
+    _Runner310
+        Context manager with run() method for executing coroutines
     """
     Runner = getattr(asyncio, "Runner", None)
     if Runner is not None:

--- a/src/pytest_doctest_docutils.py
+++ b/src/pytest_doctest_docutils.py
@@ -23,7 +23,11 @@ import pytest
 from _pytest import outcomes
 from _pytest.outcomes import OutcomeException
 
-from doctest_docutils import DocutilsDocTestFinder, _ensure_directives_registered
+from doctest_docutils import (
+    AsyncDocTestRunner,
+    DocutilsDocTestFinder,
+    _ensure_directives_registered,
+)
 
 if t.TYPE_CHECKING:
     import pathlib
@@ -137,11 +141,11 @@ def _is_doctest(
 def _init_runner_class() -> type[doctest.DocTestRunner]:
     import doctest
 
-    class PytestDoctestRunner(doctest.DebugRunner):
-        """Runner to collect failures.
+    class PytestDoctestRunner(AsyncDocTestRunner):
+        """Runner to collect failures with async support.
 
-        Note that the out variable in this case is a list instead of a
-        stdout-like object.
+        Extends AsyncDocTestRunner to enable top-level await in doctests.
+        The out variable in this case is a list instead of a stdout-like object.
         """
 
         def __init__(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ https://docs.pytest.org/en/stable/deprecations.html
 
 from __future__ import annotations
 
+import asyncio
 import pathlib
 import typing as t
 
@@ -80,3 +81,14 @@ def make_app_params(
         return args, kws
 
     return fn
+
+
+@pytest.fixture(autouse=True)
+def doctest_namespace(doctest_namespace: dict[str, t.Any]) -> dict[str, t.Any]:
+    """Inject common fixtures into doctest namespace.
+
+    Provides:
+    - asyncio: The asyncio module for async doctests
+    """
+    doctest_namespace["asyncio"] = asyncio
+    return doctest_namespace

--- a/tests/test_async_doctest.py
+++ b/tests/test_async_doctest.py
@@ -36,7 +36,18 @@ class AsyncDoctestFixture(t.NamedTuple):
 
 
 def _rst_content(body: str) -> str:
-    """Wrap doctest body in RST format."""
+    """Wrap doctest body in RST format.
+
+    Parameters
+    ----------
+    body : str
+        The doctest example code to embed
+
+    Returns
+    -------
+    str
+        RST document with title and doctest body
+    """
     return f"""\
 Test
 ====
@@ -46,7 +57,18 @@ Test
 
 
 def _md_content(body: str) -> str:
-    """Wrap doctest body in Markdown format."""
+    """Wrap doctest body in Markdown format.
+
+    Parameters
+    ----------
+    body : str
+        The doctest example code to embed
+
+    Returns
+    -------
+    str
+        Markdown document with heading and fenced code block
+    """
     return f"""\
 # Test
 

--- a/tests/test_async_doctest.py
+++ b/tests/test_async_doctest.py
@@ -1,0 +1,529 @@
+"""Tests for async doctest support.
+
+These tests verify that top-level await works in doctests without requiring
+asyncio.run() boilerplate. Tests cover both RST and Markdown formats.
+"""
+
+from __future__ import annotations
+
+import textwrap
+import typing as t
+
+import _pytest.pytester
+import pytest
+
+from doctest_docutils import AsyncDocTestRunner, DocutilsDocTestFinder
+
+if t.TYPE_CHECKING:
+    import pathlib
+
+# Type alias for fixture file content
+FixtureFileDict = dict[str, str]
+
+
+# =============================================================================
+# Fixtures: Basic async doctests
+# =============================================================================
+
+
+class AsyncDoctestFixture(t.NamedTuple):
+    """Test fixture for async doctest functionality."""
+
+    test_id: str
+    file_ext: str
+    content: str
+    expected_passed: int
+
+
+def _rst_content(body: str) -> str:
+    """Wrap doctest body in RST format."""
+    return f"""\
+Test
+====
+
+{body}
+"""
+
+
+def _md_content(body: str) -> str:
+    """Wrap doctest body in Markdown format."""
+    return f"""\
+# Test
+
+```python
+{body}
+```
+"""
+
+
+# Doctest bodies (format-agnostic)
+TOP_LEVEL_AWAIT_BODY = """\
+>>> import asyncio
+>>> await asyncio.sleep(0)
+>>> 1 + 1
+2"""
+
+ASYNC_RETURN_VALUE_BODY = """\
+>>> import asyncio
+>>> async def get_value():
+...     await asyncio.sleep(0)
+...     return 42
+>>> await get_value()
+42"""
+
+MIXED_SYNC_ASYNC_BODY = """\
+>>> x = 1
+>>> import asyncio
+>>> await asyncio.sleep(0)
+>>> x + 1
+2
+>>> y = await asyncio.sleep(0) or 10
+>>> y
+10"""
+
+STATE_PERSISTENCE_BODY = """\
+>>> import asyncio
+>>> async def set_value():
+...     global shared_value
+...     await asyncio.sleep(0)
+...     shared_value = 'hello'
+>>> await set_value()
+>>> shared_value
+'hello'"""
+
+ASYNC_CONTEXT_MANAGER_BODY = """\
+>>> import asyncio
+>>> class AsyncCM:
+...     async def __aenter__(self):
+...         await asyncio.sleep(0)
+...         return 'entered'
+...     async def __aexit__(self, *args):
+...         await asyncio.sleep(0)
+>>> async with AsyncCM() as value:
+...     print(value)
+entered"""
+
+ASYNC_FOR_BODY = """\
+>>> import asyncio
+>>> async def async_range(n):
+...     for i in range(n):
+...         await asyncio.sleep(0)
+...         yield i
+>>> result = []
+>>> async for x in async_range(3):
+...     result.append(x)
+>>> result
+[0, 1, 2]"""
+
+ASYNC_COMPREHENSION_BODY = """\
+>>> import asyncio
+>>> async def async_range(n):
+...     for i in range(n):
+...         await asyncio.sleep(0)
+...         yield i
+>>> [x async for x in async_range(3)]
+[0, 1, 2]"""
+
+EXPECTED_EXCEPTION_BODY = """\
+>>> import asyncio
+>>> async def raise_error():
+...     await asyncio.sleep(0)
+...     raise ValueError('test error')
+>>> await raise_error()
+Traceback (most recent call last):
+    ...
+ValueError: test error"""
+
+SYNC_CODE_BODY = """\
+>>> 1 + 1
+2
+>>> x = 'hello'
+>>> x.upper()
+'HELLO'"""
+
+
+BASIC_ASYNC_FIXTURES: list[AsyncDoctestFixture] = [
+    # Top-level await
+    AsyncDoctestFixture(
+        test_id="top-level-await-rst",
+        file_ext=".rst",
+        content=_rst_content(TOP_LEVEL_AWAIT_BODY),
+        expected_passed=3,
+    ),
+    AsyncDoctestFixture(
+        test_id="top-level-await-md",
+        file_ext=".md",
+        content=_md_content(TOP_LEVEL_AWAIT_BODY),
+        expected_passed=3,
+    ),
+    # Async return value
+    AsyncDoctestFixture(
+        test_id="async-return-value-rst",
+        file_ext=".rst",
+        content=_rst_content(ASYNC_RETURN_VALUE_BODY),
+        expected_passed=3,
+    ),
+    AsyncDoctestFixture(
+        test_id="async-return-value-md",
+        file_ext=".md",
+        content=_md_content(ASYNC_RETURN_VALUE_BODY),
+        expected_passed=3,
+    ),
+    # Mixed sync/async
+    AsyncDoctestFixture(
+        test_id="mixed-sync-async-rst",
+        file_ext=".rst",
+        content=_rst_content(MIXED_SYNC_ASYNC_BODY),
+        expected_passed=6,
+    ),
+    AsyncDoctestFixture(
+        test_id="mixed-sync-async-md",
+        file_ext=".md",
+        content=_md_content(MIXED_SYNC_ASYNC_BODY),
+        expected_passed=6,
+    ),
+    # State persistence
+    AsyncDoctestFixture(
+        test_id="state-persistence-rst",
+        file_ext=".rst",
+        content=_rst_content(STATE_PERSISTENCE_BODY),
+        expected_passed=4,
+    ),
+    AsyncDoctestFixture(
+        test_id="state-persistence-md",
+        file_ext=".md",
+        content=_md_content(STATE_PERSISTENCE_BODY),
+        expected_passed=4,
+    ),
+    # Sync code still works
+    AsyncDoctestFixture(
+        test_id="sync-code-rst",
+        file_ext=".rst",
+        content=_rst_content(SYNC_CODE_BODY),
+        expected_passed=3,
+    ),
+    AsyncDoctestFixture(
+        test_id="sync-code-md",
+        file_ext=".md",
+        content=_md_content(SYNC_CODE_BODY),
+        expected_passed=3,
+    ),
+]
+
+ADVANCED_ASYNC_FIXTURES: list[AsyncDoctestFixture] = [
+    # Async context manager
+    AsyncDoctestFixture(
+        test_id="async-context-manager-rst",
+        file_ext=".rst",
+        content=_rst_content(ASYNC_CONTEXT_MANAGER_BODY),
+        expected_passed=3,
+    ),
+    AsyncDoctestFixture(
+        test_id="async-context-manager-md",
+        file_ext=".md",
+        content=_md_content(ASYNC_CONTEXT_MANAGER_BODY),
+        expected_passed=3,
+    ),
+    # Async for
+    AsyncDoctestFixture(
+        test_id="async-for-rst",
+        file_ext=".rst",
+        content=_rst_content(ASYNC_FOR_BODY),
+        expected_passed=5,
+    ),
+    AsyncDoctestFixture(
+        test_id="async-for-md",
+        file_ext=".md",
+        content=_md_content(ASYNC_FOR_BODY),
+        expected_passed=5,
+    ),
+    # Async comprehension
+    AsyncDoctestFixture(
+        test_id="async-comprehension-rst",
+        file_ext=".rst",
+        content=_rst_content(ASYNC_COMPREHENSION_BODY),
+        expected_passed=3,
+    ),
+    AsyncDoctestFixture(
+        test_id="async-comprehension-md",
+        file_ext=".md",
+        content=_md_content(ASYNC_COMPREHENSION_BODY),
+        expected_passed=3,
+    ),
+    # Expected exception
+    AsyncDoctestFixture(
+        test_id="expected-exception-rst",
+        file_ext=".rst",
+        content=_rst_content(EXPECTED_EXCEPTION_BODY),
+        expected_passed=3,
+    ),
+    AsyncDoctestFixture(
+        test_id="expected-exception-md",
+        file_ext=".md",
+        content=_md_content(EXPECTED_EXCEPTION_BODY),
+        expected_passed=3,
+    ),
+]
+
+
+# =============================================================================
+# Fixtures: Plugin integration tests
+# =============================================================================
+
+
+class AsyncPluginFixture(t.NamedTuple):
+    """Test fixture for async doctest pytest plugin integration."""
+
+    test_id: str
+    file_ext: str
+    content: str
+    expected_passed: int
+
+
+PLUGIN_FIXTURES: list[AsyncPluginFixture] = [
+    AsyncPluginFixture(
+        test_id="plugin-async-rst",
+        file_ext=".rst",
+        content=_rst_content(TOP_LEVEL_AWAIT_BODY),
+        expected_passed=1,  # One doctest file
+    ),
+    AsyncPluginFixture(
+        test_id="plugin-async-md",
+        file_ext=".md",
+        content=_md_content(TOP_LEVEL_AWAIT_BODY),
+        expected_passed=1,
+    ),
+]
+
+
+# =============================================================================
+# Tests: Basic async doctests using run_doctest_docutils
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    AsyncDoctestFixture._fields,
+    BASIC_ASYNC_FIXTURES,
+    ids=[f.test_id for f in BASIC_ASYNC_FIXTURES],
+)
+def test_async_doctest_basic(
+    tmp_path: pathlib.Path,
+    test_id: str,
+    file_ext: str,
+    content: str,
+    expected_passed: int,
+) -> None:
+    """Test basic async doctest functionality with top-level await."""
+    doc = tmp_path / f"test{file_ext}"
+    doc.write_text(content)
+
+    finder = DocutilsDocTestFinder()
+    runner = AsyncDocTestRunner(verbose=False)
+
+    text = doc.read_text()
+    total_attempted = 0
+    total_failed = 0
+
+    for test in finder.find(text, str(doc)):
+        result = runner.run(test)
+        total_attempted += result.attempted
+        total_failed += result.failed
+
+    assert total_failed == 0, f"Expected no failures, got {total_failed}"
+    assert total_attempted == expected_passed, (
+        f"Expected {expected_passed} examples, got {total_attempted}"
+    )
+
+
+@pytest.mark.parametrize(
+    AsyncDoctestFixture._fields,
+    ADVANCED_ASYNC_FIXTURES,
+    ids=[f.test_id for f in ADVANCED_ASYNC_FIXTURES],
+)
+def test_async_doctest_advanced(
+    tmp_path: pathlib.Path,
+    test_id: str,
+    file_ext: str,
+    content: str,
+    expected_passed: int,
+) -> None:
+    """Test advanced async doctest scenarios."""
+    doc = tmp_path / f"test{file_ext}"
+    doc.write_text(content)
+
+    finder = DocutilsDocTestFinder()
+    runner = AsyncDocTestRunner(verbose=False)
+
+    text = doc.read_text()
+    total_attempted = 0
+    total_failed = 0
+
+    for test in finder.find(text, str(doc)):
+        result = runner.run(test)
+        total_attempted += result.attempted
+        total_failed += result.failed
+
+    assert total_failed == 0, f"Expected no failures, got {total_failed}"
+    assert total_attempted == expected_passed, (
+        f"Expected {expected_passed} examples, got {total_attempted}"
+    )
+
+
+# =============================================================================
+# Tests: Plugin integration using pytester
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    AsyncPluginFixture._fields,
+    PLUGIN_FIXTURES,
+    ids=[f.test_id for f in PLUGIN_FIXTURES],
+)
+def test_async_doctest_plugin(
+    pytester: _pytest.pytester.Pytester,
+    test_id: str,
+    file_ext: str,
+    content: str,
+    expected_passed: int,
+) -> None:
+    """Test async doctest collection and execution via pytest plugin."""
+    pytester.plugins = ["pytest_doctest_docutils"]
+    pytester.makefile(
+        ".ini",
+        pytest=textwrap.dedent("""
+            [pytest]
+            addopts = --doctest-glob=*.rst --doctest-glob=*.md
+        """),
+    )
+
+    # Create test file
+    test_file = pytester.path / f"test{file_ext}"
+    test_file.write_text(content)
+
+    result = pytester.runpytest(str(test_file))
+    result.assert_outcomes(passed=expected_passed)
+
+
+def test_async_doctest_plugin_with_conftest(
+    pytester: _pytest.pytester.Pytester,
+) -> None:
+    """Test async doctest with conftest fixtures via pytest plugin."""
+    pytester.plugins = ["pytest_doctest_docutils"]
+    pytester.makefile(
+        ".ini",
+        pytest=textwrap.dedent("""
+            [pytest]
+            addopts = --doctest-glob=*.rst --doctest-glob=*.md
+        """),
+    )
+
+    # Create conftest with doctest_namespace fixture
+    pytester.makeconftest(
+        textwrap.dedent("""
+            import asyncio
+            import pytest
+
+            @pytest.fixture(autouse=True)
+            def add_doctest_fixtures(doctest_namespace):
+                async def async_add(a, b):
+                    await asyncio.sleep(0)
+                    return a + b
+                doctest_namespace["async_add"] = async_add
+                doctest_namespace["asyncio"] = asyncio
+        """),
+    )
+
+    # Create test file using the fixture
+    test_content = _rst_content("""\
+>>> result = await async_add(2, 3)
+>>> result
+5""")
+
+    test_file = pytester.path / "test.rst"
+    test_file.write_text(test_content)
+
+    result = pytester.runpytest(str(test_file))
+    result.assert_outcomes(passed=1)
+
+
+def test_async_doctest_plugin_failure_reporting(
+    pytester: _pytest.pytester.Pytester,
+) -> None:
+    """Test that async doctest failures are properly reported."""
+    pytester.plugins = ["pytest_doctest_docutils"]
+    pytester.makefile(
+        ".ini",
+        pytest=textwrap.dedent("""
+            [pytest]
+            addopts = --doctest-glob=*.rst
+        """),
+    )
+
+    # Create test file with intentional failure
+    test_content = _rst_content("""\
+>>> import asyncio
+>>> async def wrong():
+...     await asyncio.sleep(0)
+...     return 999
+>>> await wrong()
+42""")
+
+    test_file = pytester.path / "test.rst"
+    test_file.write_text(test_content)
+
+    result = pytester.runpytest(str(test_file))
+    result.assert_outcomes(failed=1)
+
+
+# =============================================================================
+# Tests: Direct AsyncDocTestRunner usage
+# =============================================================================
+
+
+def test_async_runner_state_persists(tmp_path: pathlib.Path) -> None:
+    """Test that state persists across async examples in same DocTest block."""
+    doc = tmp_path / "test.rst"
+    doc.write_text("""\
+>>> import asyncio
+>>> counter = 0
+>>> async def increment():
+...     global counter
+...     await asyncio.sleep(0)
+...     counter += 1
+>>> await increment()
+>>> await increment()
+>>> counter
+2
+""")
+
+    finder = DocutilsDocTestFinder()
+    runner = AsyncDocTestRunner(verbose=False)
+
+    text = doc.read_text()
+    for test in finder.find(text, str(doc)):
+        result = runner.run(test)
+        assert result.failed == 0, "State should persist across examples"
+
+
+def test_async_runner_handles_sync_and_async(tmp_path: pathlib.Path) -> None:
+    """Test that sync and async code both work correctly."""
+    doc = tmp_path / "test.rst"
+    doc.write_text("""\
+>>> sync_value = 'hello'
+>>> import asyncio
+>>> async def async_upper(s):
+...     await asyncio.sleep(0)
+...     return s.upper()
+>>> await async_upper(sync_value)
+'HELLO'
+>>> sync_value
+'hello'
+""")
+
+    finder = DocutilsDocTestFinder()
+    runner = AsyncDocTestRunner(verbose=False)
+
+    text = doc.read_text()
+    for test in finder.find(text, str(doc)):
+        result = runner.run(test)
+        assert result.failed == 0, "Both sync and async should work"


### PR DESCRIPTION
## Summary

Enable clean async doctests without `asyncio.run()` boilerplate:

```python
# BEFORE (ugly boilerplate)
>>> async def example():
...     result = await fetch_data()
...     return result
>>> asyncio.run(example())
42

# AFTER (clean top-level await)
>>> result = await fetch_data()
>>> result
42
```

## Implementation

- Uses Python 3.8+ `PyCF_ALLOW_TOP_LEVEL_AWAIT` compile flag
- Detects `CO_COROUTINE` flag to transparently handle sync vs async code
- One `asyncio.Runner` per DocTest block (allows `create_task()` in one line, `await` in the next)
- `_Runner310` shim provides Python 3.10 compatibility (asyncio.Runner is 3.11+)
- Renamed `testdocutils` → `run_doctest_docutils` to avoid pytest auto-collection

## Test plan

- [x] Basic top-level await: `>>> await asyncio.sleep(0)`
- [x] Async functions with return values
- [x] Mixed sync/async examples in same block
- [x] State persistence across examples
- [x] Async context managers (`async with`)
- [x] Async iteration (`async for`)
- [x] Async comprehensions
- [x] Expected exceptions in async code
- [x] Markdown file support
- [x] All 95 existing tests pass